### PR TITLE
#166907930 implement endpoint that marks advert as sold

### DIFF
--- a/Server/Routes/property.routes.js
+++ b/Server/Routes/property.routes.js
@@ -1,7 +1,8 @@
 import { Router } from 'express';
 import { cloudinaryConfig } from '../config/cloudinaryConfig';
 import { multerUploads } from '../middleware/multer';
-import { postAdvert, updateAdvert } from '../controllers/property.controller';
+import {
+  postAdvert, updateAdvert, markSold } from '../controllers/property.controller';
 import { checkToken } from '../middleware/tokenHandler';
 import { propertyValidator } from '../middleware/validator';
 
@@ -9,7 +10,7 @@ const router = Router();
 
 router.post('/', checkToken, cloudinaryConfig, multerUploads, propertyValidator, postAdvert);
 router.patch('/:propertyId', checkToken, cloudinaryConfig, multerUploads, propertyValidator, updateAdvert);
-router.patch('/:propertyId/sold', checkToken, updateAdvert);
+router.patch('/:propertyId/sold', checkToken, markSold);
 
 
 export default router;

--- a/Server/controllers/authentication.controller.js
+++ b/Server/controllers/authentication.controller.js
@@ -39,7 +39,7 @@ const login = async (req, res) => {
     }
     const token = generateToken(displayResult);
     displayResult.token = token;
-    return userResponse(res, 201, displayResult);
+    return userResponse(res, 200, displayResult);
   } catch (err) {
     return serverError(res);
   }

--- a/Server/controllers/property.controller.js
+++ b/Server/controllers/property.controller.js
@@ -40,8 +40,7 @@ const updateAdvert = async (req, res) => {
     }
     const propId = Number(req.params.propertyId);
     const propArray = propertyObj.findAllUsers();
-    const propToUpdate = propArray.filter(property => property.id === propId);
-    const propertyData = propToUpdate[0];
+    const propertyData = propArray.find(property => property.id === propId);
     const propIndex = propArray.findIndex(property => property.id === propId);
     const {
       state, city, address, type, price
@@ -53,10 +52,24 @@ const updateAdvert = async (req, res) => {
     propertyData.image_url = (propertyData.image_url === image_url) ? propertyData.image_url : image_url;
     propertyData.type = (propertyData.type === type) ? propertyData.type : type;
     propertyObj.updateAdvert(propertyData, propIndex);
-    return serverResponse(res, 201, 'status', 'success', 'data', propertyData);
+    return serverResponse(res, 200, 'status', 'success', 'data', propertyData);
   } catch (err) {
     return serverError(res);
   }
 };
 
-export { postAdvert, updateAdvert };
+const markSold = (req, res) => {
+  try {
+    const id = Number(req.params.propertyId);
+    const propArray = propertyObj.findAllUsers();
+    const propToUpdate = propArray.find(property => property.id === id);
+    const propIndex = propArray.findIndex(property => property.id === id);
+    propToUpdate.status = 'sold';
+    propertyObj.updateAdvert(propToUpdate, propIndex);
+    return serverResponse(res, 200, 'status', 'success', 'data', propToUpdate);
+  } catch (err) {
+    return serverError(res);
+  }
+};
+
+export { postAdvert, updateAdvert, markSold };

--- a/Server/models/property.model.js
+++ b/Server/models/property.model.js
@@ -54,7 +54,6 @@ class Property {
 
   updateAdvert(propObj, propId) {
     this.propertyList.splice(propId, 1, propObj);
-    console.log(this.propertyList);
     return this.propertyList;
   }
 }

--- a/Server/test/app.test.js
+++ b/Server/test/app.test.js
@@ -57,7 +57,7 @@ describe('TESTING AUTHENTICATION ENDPOINTS', () => {
       })
       .end((err, res) => {
         if (err) return done(err);
-        expect(res.status).to.equal(201);
+        expect(res.status).to.equal(200);
         expect(res.body).to.be.an('object');
         expect(res.body).to.haveOwnProperty('status');
         expect(res.body).to.haveOwnProperty('status').that.is.a('string');
@@ -121,7 +121,29 @@ describe('TESTING PROPERTY ENDPOINTS', () => {
           done(err);
         }
         expect(res.body).to.have.keys('status', 'data');
-        expect(res.status).to.equal(201);
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.ownProperty('status').that.equals('success');
+        expect(res.body).to.have.ownProperty('data').to.be.an('object');
+        expect(res.body.data.id).to.be.a('number');
+        expect(res.body.data.status).to.be.a('string');
+        expect(res.body.data.state).to.be.a('string');
+        expect(res.body.data.type).to.be.a('string');
+        expect(res.body.data.city).to.be.a('string');
+        expect(res.body.data.address).to.be.a('string');
+        expect(res.body.data.image_url).to.be.a('string');
+        expect(res.body.data.price).to.be.a('number');
+        done();
+      });
+  });
+  it('should update property advert as Sold', (done) => {
+    chai.request(server)
+      .patch('/api/v1/property/3/sold')
+      .set('Authorization', `Bearer ${testToken}`)
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res.body).to.have.keys('status', 'data');
+        expect(res.status).to.equal(200);
         expect(res.body).to.be.an('object');
         expect(res.body).to.have.ownProperty('status').that.equals('success');
         expect(res.body).to.have.ownProperty('data').to.be.an('object');


### PR DESCRIPTION
#### Mark property advert as sold
- The mark-property-advert-as-sold endpoint was created to enable registered users(agents) who have sold an advertised property to mark them as sold so that users know it’s no longer available​.

#### Tasks
- I wrote a pivotal tracker story for the endpoint
- I wrote tests for the endpoint
- I created a branch of develop on which the endpoint was built
- I wrote a model function for the endpoint
- I wrote a controller function which transforms and retrieves user data for comparison and access
- I wrote a function to validate user's data with the help of npm module "Joi"


#### Pivotal Tracker Link : https://www.pivotaltracker.com/story/show/166907930

#### Testing
Tests were written for the endpoint using mocha and chai testing suites
