### PR TITLE
#166915410 implement endpoint that deletes a property advert

### DIFF
--- a/Server/Routes/property.routes.js
+++ b/Server/Routes/property.routes.js
@@ -2,7 +2,8 @@ import { Router } from 'express';
 import { cloudinaryConfig } from '../config/cloudinaryConfig';
 import { multerUploads } from '../middleware/multer';
 import {
-  postAdvert, updateAdvert, markSold } from '../controllers/property.controller';
+  postAdvert, updateAdvert, markSold, deleteAdvert
+} from '../controllers/property.controller';
 import { checkToken } from '../middleware/tokenHandler';
 import { propertyValidator } from '../middleware/validator';
 
@@ -11,6 +12,7 @@ const router = Router();
 router.post('/', checkToken, cloudinaryConfig, multerUploads, propertyValidator, postAdvert);
 router.patch('/:propertyId', checkToken, cloudinaryConfig, multerUploads, propertyValidator, updateAdvert);
 router.patch('/:propertyId/sold', checkToken, markSold);
+router.delete('/:propertyId', checkToken, deleteAdvert);
 
 
 export default router;

--- a/Server/app.js
+++ b/Server/app.js
@@ -1,6 +1,6 @@
 import express from 'express';
-import authenticationRouter from './routes/authentication.routes';
-import propertyRouter from './routes/property.routes';
+import authenticationRouter from './Routes/authentication.routes';
+import propertyRouter from './Routes/property.routes';
 
 
 const app = express();

--- a/Server/controllers/property.controller.js
+++ b/Server/controllers/property.controller.js
@@ -72,4 +72,20 @@ const markSold = (req, res) => {
   }
 };
 
-export { postAdvert, updateAdvert, markSold };
+const deleteAdvert = (req, res) => {
+  try {
+    const id = Number(req.params.propertyId);
+    const propToDelete = propertyObj.deleteProp(id);
+    if (propToDelete) {
+      return serverResponse(res, 200, 'status', 'success', 'data', { message: 'Advert deleted Successfully' });
+    }
+    return serverResponse(res, 404, 'status', 'error', 'error', 'Advert not found. Advert may have been removed');
+
+  } catch (err) {
+    return serverError(res);
+  }
+};
+
+export {
+  postAdvert, updateAdvert, markSold, deleteAdvert
+};

--- a/Server/models/property.model.js
+++ b/Server/models/property.model.js
@@ -56,6 +56,16 @@ class Property {
     this.propertyList.splice(propId, 1, propObj);
     return this.propertyList;
   }
+
+  deleteProp(id) {
+    const propArr = this.propertyList;
+    const propIndex = propArr.findIndex(property => property.id === id);
+    if (propIndex > -1) {
+      propArr.splice(propIndex, 1);
+      return true;
+    }
+    return false;
+  }
 }
 
 

--- a/Server/test/app.test.js
+++ b/Server/test/app.test.js
@@ -158,4 +158,38 @@ describe('TESTING PROPERTY ENDPOINTS', () => {
         done();
       });
   });
+  it('should delete a property advert', (done) => {
+    chai.request(server)
+      .delete('/api/v1/property/3')
+      .set('Authorization', `Bearer ${testToken}`)
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res.body).to.have.keys('status', 'data');
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.ownProperty('status').that.equals('success');
+        expect(res.body).to.have.ownProperty('data').to.be.an('object');
+        expect(res.body.status).to.be.a('string');
+        expect(res.body.data).to.be.an('object');
+        expect(res.body.data.message).to.be.an('string');
+        done();
+      });
+  });
+  it('should return message "Advert not found. Advert may have been removed" if property ID does not exist', (done) => {
+    chai.request(server)
+      .delete('/api/v1/property/6')
+      .set('Authorization', `Bearer ${testToken}`)
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res.body).to.have.keys('status', 'error');
+        expect(res.status).to.equal(404);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.ownProperty('status').that.equals('error');
+        expect(res.body).to.have.ownProperty('error').to.be.a('string');
+        expect(res.body.status).to.be.a('string');
+        expect(res.body.error).to.be.a('string');
+        expect(res.body.error).to.equal('Advert not found. Advert may have been removed');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
#### Delete property-advert endpoint
- The delete-property-advert endpoint was created to enable registered users(agents) who wish to a delete property advert posted by them to do so.

#### Tasks
- I wrote a pivotal tracker story for the endpoint
- I wrote tests for the endpoint
- I created a branch of develop on which the endpoint was built
- I wrote a model function for the endpoint
- I wrote a controller function which compliments the model function in bringing about a successful delete of the advert
- I wrote a function to validate user's data with the help of npm module "Joi"


#### Pivotal Tracker Link : https://www.pivotaltracker.com/story/show/166915410

#### Testing
Tests were written for the endpoint using mocha and chai testing suites
