### PR TITLE
#166944436 implement endpoint to fetch specific property advert

### DIFF
--- a/Server/controllers/property.controller.js
+++ b/Server/controllers/property.controller.js
@@ -116,6 +116,23 @@ const getAllAdverts = (req, res) => {
   }
 };
 
+const getOneAdvert = (req, res) => {
+  try {
+    const id = Number(req.params.propertyId);
+    const result = propertyObj.findOne(id);
+    if (!result) return serverResponse(res, 404, 'status', 'error', 'error', 'No result found. Enter a valid value and try again.');
+    const advertOwnerID = result.owner;
+    const userList = userObj.findAllUsers();
+    const advertOwner = userList.find(user => user.id === advertOwnerID);
+    result.ownerEmail = advertOwner.email;
+    result.ownerPhoneNumber = advertOwner.phoneNumber;
+    const { owner, ...finalResult } = result;
+    return serverResponse(res, 200, 'status', 'success', 'data', finalResult);
+  } catch (err) {
+    return serverError(res);
+  }
+};
+
 export {
   postAdvert, updateAdvert, markSold, deleteAdvert, getAllAdverts, getOneAdvert
 };

--- a/Server/test/app.test.js
+++ b/Server/test/app.test.js
@@ -183,7 +183,29 @@ describe('TESTING PROPERTY ENDPOINTS', () => {
         done();
       });
   });
-
+  it('should retrieve A SPECIFIC PROPERTY', (done) => {
+    chai.request(server)
+      .get('/api/v1/property/1')
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res.body).to.have.keys('status', 'data');
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.ownProperty('status').that.equals('success');
+        expect(res.body).to.have.ownProperty('data').to.be.an('object');
+        expect(res.body.data.id).to.be.a('number');
+        expect(res.body.data.status).to.be.a('string');
+        expect(res.body.data.state).to.be.a('string');
+        expect(res.body.data.type).to.be.a('string');
+        expect(res.body.data.city).to.be.a('string');
+        expect(res.body.data.address).to.be.a('string');
+        expect(res.body.data.image_url).to.be.a('string');
+        expect(res.body.data.price).to.be.a('number');
+        expect(res.body.data.ownerEmail).to.be.a('string');
+        expect(res.body.data.ownerPhoneNumber).to.be.a('string');
+        done();
+      });
+  });
   it('should return an error when an invalid or a non-existent property type is entered', (done) => {
     chai.request(server)
       .get('/api/v1/property?type=3-Bedroom')


### PR DESCRIPTION
#### Get a specific property-advert endpoint
- The get-specific-property-advert endpoint was created to enable all users and visitors access to a specified property advert on the platform.

#### Tasks
- I wrote a pivotal tracker story for the endpoint
- I wrote tests for the endpoint
- I created a branch of develop on which the endpoint was built
- I wrote a controller function to implement the endpoint


#### Pivotal Tracker Link : https://www.pivotaltracker.com/story/show/166944436

#### Testing
Tests were written for the endpoint using mocha and chai testing suites
