### PR TITLE
#167202746 implement post-property-advert endpoint - CHALLENGE 3

### DIFF
--- a/Server/Routes/authentication.routes.js
+++ b/Server/Routes/authentication.routes.js
@@ -1,4 +1,4 @@
-import { Router } from './node_modules/express';
+import { Router } from 'express';
 import { signupValidator, loginValidator } from '../middleware/validator';
 import userController from '../controllers/authentication.controller';
 

--- a/Server/Routes/property.routes.js
+++ b/Server/Routes/property.routes.js
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import { cloudinaryConfig } from '../config/cloudinaryConfig';
+import { multerUploads } from '../middleware/multer';
+import propController from '../controllers/property.controller';
+import { checkToken } from '../middleware/tokenHandler';
+import { propertyValidator } from '../middleware/validator';
+
+const router = Router();
+
+const { postAdvert } = propController;
+
+router.post('/', checkToken, cloudinaryConfig, multerUploads, propertyValidator, postAdvert);
+
+
+export default router;

--- a/Server/app.js
+++ b/Server/app.js
@@ -3,6 +3,7 @@ import cors from 'cors';
 import debug from 'debug';
 import swaggerUi from 'swagger-ui-express';
 import authenticationRouter from './Routes/authentication.routes';
+import propertyRouter from './Routes/property.routes';
 import swaggerDocument from '../swagger.json';
 
 
@@ -18,6 +19,7 @@ app.get('/', (req, res) => {
   res.send("Welcome to my Property-Pro Lite Endpoints' Page");
 });
 app.use('/api/v1/auth/', authenticationRouter);
+app.use('/api/v1/property/', propertyRouter);
 
 const port = process.env.PORT || 3000;
 

--- a/Server/controllers/property.controller.js
+++ b/Server/controllers/property.controller.js
@@ -1,0 +1,34 @@
+
+import debug from 'debug';
+import { serverError, serverResponse } from '../helper/serverResponse';
+import { imageUpload } from '../middleware/multer';
+import Model from '../models/Model';
+
+
+const logger = debug(`pro-lite-propsController`);
+const propModel = new Model('property');
+
+export default class Property {
+  static async postAdvert(req, res) {
+    try {
+      const { id } = req.tokenData;
+      let image_url;
+      if (req.file) {
+        const fileUrl = await imageUpload(req);
+        if (!fileUrl) image_url = 'https://dummytesturl.com';
+        else image_url = fileUrl;
+      }
+      const {
+        state, city, address, type, price
+      } = req.body;
+      const columns = `state, city, type, address, price, image_url, owner`;
+      const values = `'${state}', '${city}', '${type}', '${address}', '${price}', '${image_url}', '${id}'`;
+      const result = await propModel.insert(columns, values);
+
+      return serverResponse(res, 201, ...['status', 'success', 'data', result]);
+    } catch (err) {
+      logger(`${err}`);
+      return serverError(res);
+    }
+  }
+}

--- a/Server/test/app.test.js
+++ b/Server/test/app.test.js
@@ -2,16 +2,14 @@ import 'dotenv/config';
 import path from 'path';
 import chai from 'chai';
 import chaiHttp from 'chai-http';
-import debug from 'debug';
 import server from '../app';
 
-const logger = debug(`pro-lite-test`);
 
 const { expect } = chai;
 chai.use(chaiHttp);
 
 
-const testToken = null;
+let testToken = null;
 describe('TESTING AUTHENTICATION ENDPOINTS', () => {
   it('should welcome you to the Applications endpoint page', (done) => {
     chai.request(server)
@@ -34,6 +32,7 @@ describe('TESTING AUTHENTICATION ENDPOINTS', () => {
         address: 'Gwarinpa, Abuja'
       })
       .end((err, res) => {
+        testToken = res.body.data.token;
         if (err) return done(err);
         expect(res.body).to.haveOwnProperty('status');
         expect(res.status).to.equal(201);
@@ -73,6 +72,37 @@ describe('TESTING AUTHENTICATION ENDPOINTS', () => {
         expect((res.body.data.last_name)).to.be.a('string');
         expect((res.body.data.token)).to.be.a('string');
         expect((res.body.data.id)).to.be.a('number');
+        done();
+      });
+  });
+});
+
+describe('TESTING PROPERTY ENDPOINTS', () => {
+  it('should save property advert details provided by user', (done) => {
+    chai.request(server)
+      .post('/api/v1/property')
+      .set('Authorization', `Bearer ${testToken}`)
+      .field('price', 3500000)
+      .field('state', 'Lagos')
+      .field('city', 'Ikeja')
+      .field('address', 'Odalume, Ladipo, Lagos State')
+      .field('type', '2-bedroom')
+      .attach('image', path.join(`${__dirname}/images/colourful.jpg`))
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res.body).to.have.keys('status', 'data');
+        expect(res.status).to.equal(201);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.ownProperty('status').that.equals('success');
+        expect(res.body).to.have.ownProperty('data').to.be.an('object');
+        expect(res.body.data.id).to.be.a('number');
+        expect(res.body.data.status).to.be.a('string');
+        expect(res.body.data.state).to.be.a('string');
+        expect(res.body.data.type).to.be.a('string');
+        expect(res.body.data.city).to.be.a('string');
+        expect(res.body.data.address).to.be.a('string');
+        expect(res.body.data.image_url).to.be.a('string');
+        expect(res.body.data.price).to.be.a('number');
         done();
       });
   });

--- a/Server/test/encrypt.test.js
+++ b/Server/test/encrypt.test.js
@@ -1,20 +1,30 @@
 import chai from 'chai';
 import { encryptPassword, decryptPassword } from '../helper/encrypt';
-import debug from 'debug';
-
-const logger = debug(`pro-lite-test`);
 
 const { expect } = chai;
-
-
-describe('Password Encryption and Password Decryption Tests', async () => {
-  const result = await encryptPassword("Hello");
-  const decryptResult = await decryptPassword('Hello', result);
-
-  it('should return a boolean', () => {
-    expect(result).to.be.a('string');
+describe('Password Encryption and Password Decryption Tests', () => {
+  let testResult = null;
+  it('should return a boolean', (done) => {
+    encryptPassword("Hello")
+      .then((result) => {
+        testResult = result;
+        try {
+          expect(result).to.be.a('string');
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
   });
-  it('should return a boolean', () => {
-    expect(decryptResult).to.be.a('boolean');
+  it('should return a boolean', (done) => {
+    decryptPassword('Hello', testResult)
+      .then((result) => {
+        try {
+          expect(result).to.be.a('boolean');
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
   });
 });

--- a/Server/test/validator.test.js
+++ b/Server/test/validator.test.js
@@ -1,10 +1,7 @@
 import 'dotenv/config';
 import chai from 'chai';
 import chaiHttp from 'chai-http';
-import debug from 'debug';
 import server from '../app';
-
-const logger = debug(`pro-lite-test`);
 
 const { expect } = chai;
 chai.use(chaiHttp);


### PR DESCRIPTION
#### What does this PR do?
Implements the post property advert endpoint for the Property Pro Lite
#### Description of Task to be completed?
- write tests for the post-property advert endpoint
- write post-property advert endpoint.
- run tests on endpoint and ensure it passes.

#### How should this be manually tested?
 - clone repository
- startup terminal
- cd into the cloned repository
- start server by typing ```npm start``` into the terminal
- Enter requested values into postman and see result.

#### Any background context you want to provide?
This is the re-implementation of challenge 2 post-property-advert endpoint built using only data structures.
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/167202746
#### Screenshots (if appropriate)
None
#### Questions:
None