### PR TITLE
#167217896 implement update-property-advert-endpoint - CHALLENGE 3

### DIFF
--- a/Server/Routes/property.routes.js
+++ b/Server/Routes/property.routes.js
@@ -3,13 +3,14 @@ import { cloudinaryConfig } from '../config/cloudinaryConfig';
 import { multerUploads } from '../middleware/multer';
 import propController from '../controllers/property.controller';
 import { checkToken } from '../middleware/tokenHandler';
-import { propertyValidator } from '../middleware/validator';
+import { propertyValidator, parameterValidator } from '../middleware/validator';
 
 const router = Router();
 
-const { postAdvert } = propController;
+const { postAdvert, updateAdvert } = propController;
 
 router.post('/', checkToken, cloudinaryConfig, multerUploads, propertyValidator, postAdvert);
+router.patch('/:propertyId', checkToken, cloudinaryConfig, multerUploads, parameterValidator, propertyValidator, updateAdvert);
 
 
 export default router;

--- a/Server/controllers/property.controller.js
+++ b/Server/controllers/property.controller.js
@@ -27,7 +27,28 @@ export default class Property {
 
       return serverResponse(res, 201, ...['status', 'success', 'data', result]);
     } catch (err) {
-      logger(`${err}`);
+      return serverError(res);
+    }
+  }
+
+  static async updateAdvert(req, res) {
+    try {
+      const propId = Number(req.params.propertyId);
+      const { id } = req.tokenData;
+      const {
+        state, city, address, type, price
+      } = req.body;
+      let fileUrl = null;
+      if (req.file) {
+        const imageUrl = await imageUpload(req);
+        fileUrl = (imageUrl) || 'https://dummytesturl.com';
+      }
+      const values = `state='${state}', city='${city}', type='${type}', address='${address}', price= ${price}, image_url='${fileUrl}'`;
+      const condition = `owner = ${id} AND id =${propId}`;
+      const result = await propModel.update(values, condition);
+      if (!result) return serverResponse(res, 404, ...['status', 'error', 'error', `You have no property advert with ID ${propId}. Input a correct property ID and try again`]);
+      return serverResponse(res, 200, ...['status', 'success', 'data', result]);
+    } catch (err) {
       return serverError(res);
     }
   }

--- a/Server/middleware/validator.js
+++ b/Server/middleware/validator.js
@@ -16,6 +16,9 @@ const propertySchema = Joi.object().keys({
   type: Joi.string().required(),
   address: Joi.string().required()
 });
+const parameterSchema = Joi.object().keys({
+  propertyId: Joi.number().integer().required()
+});
 const loginSchema = Joi.object().keys({
   password: Joi.required(),
   email: Joi.string().email().regex(/^\S+@\S+\.\S+$/).required()
@@ -71,5 +74,11 @@ const propertyValidator = (req, res, next) => {
     return next();
   });
 };
+const parameterValidator = (req, res, next) => Joi.validate(req.params, parameterSchema, (err, value) => {
+  if (err) return errorMessage(err, res);
+  return next();
+});
 
-export { propertyValidator, signupValidator, loginValidator };
+export {
+ propertyValidator, signupValidator, loginValidator, parameterValidator 
+};

--- a/Server/test/app.test.js
+++ b/Server/test/app.test.js
@@ -2,7 +2,10 @@ import 'dotenv/config';
 import path from 'path';
 import chai from 'chai';
 import chaiHttp from 'chai-http';
+import debug from 'debug';
 import server from '../app';
+
+const logger = debug(`pro-lite-test`);
 
 
 const { expect } = chai;
@@ -92,6 +95,34 @@ describe('TESTING PROPERTY ENDPOINTS', () => {
         if (err) done(err);
         expect(res.body).to.have.keys('status', 'data');
         expect(res.status).to.equal(201);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.ownProperty('status').that.equals('success');
+        expect(res.body).to.have.ownProperty('data').to.be.an('object');
+        expect(res.body.data.id).to.be.a('number');
+        expect(res.body.data.status).to.be.a('string');
+        expect(res.body.data.state).to.be.a('string');
+        expect(res.body.data.type).to.be.a('string');
+        expect(res.body.data.city).to.be.a('string');
+        expect(res.body.data.address).to.be.a('string');
+        expect(res.body.data.image_url).to.be.a('string');
+        expect(res.body.data.price).to.be.a('number');
+        done();
+      });
+  });
+  it('should update property advert details provided by user', (done) => {
+    chai.request(server)
+      .patch('/api/v1/property/1')
+      .set('Authorization', `Bearer ${testToken}`)
+      .field('price', 1000000)
+      .field('state', 'Kwara')
+      .field('city', 'Ilorin')
+      .field('address', '39, Balogun Fulani Road, Ilorin')
+      .field('type', '3-bedroom')
+      .attach('image', path.join(`${__dirname}/images/colourful.jpg`))
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res.body).to.have.keys('status', 'data');
+        expect(res.status).to.equal(200);
         expect(res.body).to.be.an('object');
         expect(res.body).to.have.ownProperty('status').that.equals('success');
         expect(res.body).to.have.ownProperty('data').to.be.an('object');


### PR DESCRIPTION
#### What does this PR do?
Implements the update-property-advert endpoint for the Property Pro Lite
#### Description of Task to be completed?
- write tests for the update-property-advert endpoint
- write the update-property-advert endpoint.
- run tests on endpoint and ensure it passes.

#### How should this be manually tested?
 - clone repository
- startup terminal
- cd into the cloned repository
- start server by typing ```npm start``` into the terminal
- Enter requested values into postman and see result.

#### Any background context you want to provide?
This is the re-implementation of challenge 2 post-property-advert endpoint built using only data structures.
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/167217896
#### Screenshots (if appropriate)
None
#### Questions:
None