### PR TITLE
#167219395 implement endpoint to delete advert - CHALLENGE 3

### DIFF
--- a/Server/Routes/property.routes.js
+++ b/Server/Routes/property.routes.js
@@ -7,11 +7,14 @@ import { propertyValidator, parameterValidator } from '../middleware/validator';
 
 const router = Router();
 
-const { postAdvert, updateAdvert, markSold } = propController;
+const {
+  postAdvert, updateAdvert, markSold, deleteAdvert
+} = propController;
 
 router.post('/', checkToken, cloudinaryConfig, multerUploads, propertyValidator, postAdvert);
 router.patch('/:propertyId', checkToken, cloudinaryConfig, multerUploads, parameterValidator, propertyValidator, updateAdvert);
 router.patch('/:propertyId/sold', checkToken, parameterValidator, markSold);
+router.delete('/:propertyId', checkToken, parameterValidator, deleteAdvert);
 
 
 export default router;

--- a/Server/controllers/property.controller.js
+++ b/Server/controllers/property.controller.js
@@ -66,4 +66,17 @@ export default class Property {
       return serverError(res);
     }
   }
+
+  static async deleteAdvert(req, res) {
+    try {
+      const id = Number(req.params.propertyId);
+      const { id: userID } = req.tokenData;
+      const condition = `owner = ${userID} AND id =${id}`;
+      const result = await propModel.delete(condition);
+      if (!result) return serverResponse(res, 404, ...['status', 'error', 'error', `Advert not found. Advert may have been removed`]);
+      return serverResponse(res, 200, ...['status', 'success', 'data', { message: 'Advert deleted Successfully' }]);
+    } catch (err) {
+      return serverError(res);
+    }
+  }
 }

--- a/Server/test/app.test.js
+++ b/Server/test/app.test.js
@@ -159,4 +159,38 @@ describe('TESTING PROPERTY ENDPOINTS', () => {
         done();
       });
   });
+  it('should delete a property advert', (done) => {
+    chai.request(server)
+      .delete('/api/v1/property/1')
+      .set('Authorization', `Bearer ${testToken}`)
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res.body).to.have.keys('status', 'data');
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.ownProperty('status').that.equals('success');
+        expect(res.body).to.have.ownProperty('data').to.be.an('object');
+        expect(res.body.status).to.be.a('string');
+        expect(res.body.data).to.be.an('object');
+        expect(res.body.data.message).to.be.an('string');
+        done();
+      });
+  });
+  it('should return message "Advert not found. Advert may have been removed" if property ID does not exist', (done) => {
+    chai.request(server)
+      .delete('/api/v1/property/30')
+      .set('Authorization', `Bearer ${testToken}`)
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res.body).to.have.keys('status', 'error');
+        expect(res.status).to.equal(404);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.ownProperty('status').that.equals('error');
+        expect(res.body).to.have.ownProperty('error').to.be.a('string');
+        expect(res.body.status).to.be.a('string');
+        expect(res.body.error).to.be.a('string');
+        expect(res.body.error).to.equal('Advert not found. Advert may have been removed');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
Implements the delete-property-advert endpoint for the Property Pro Lite
#### Description of Task to be completed?
- write tests for the delete-property-advert endpoint
- write the delete-property-advert endpoint.
- run tests on endpoint and ensure it passes.

#### How should this be manually tested?
 - clone repository
- startup terminal
- cd into the cloned repository
- start server by typing ```npm start``` into the terminal
- Enter requested values into postman and see result.

#### Any background context you want to provide?
This is the re-implementation of challenge-2 delete-property-advert endpoint built using only data structures.
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/167219395
#### Screenshots (if appropriate)
None
#### Questions:
None