### PR TITLE
#167220446 implement get-all-advert endpoint - CHALLENGE 3

### DIFF
--- a/Server/Routes/property.routes.js
+++ b/Server/Routes/property.routes.js
@@ -8,13 +8,14 @@ import { propertyValidator, parameterValidator } from '../middleware/validator';
 const router = Router();
 
 const {
-  postAdvert, updateAdvert, markSold, deleteAdvert
+  postAdvert, updateAdvert, markSold, getAllAdverts, deleteAdvert
 } = propController;
 
 router.post('/', checkToken, cloudinaryConfig, multerUploads, propertyValidator, postAdvert);
 router.patch('/:propertyId', checkToken, cloudinaryConfig, multerUploads, parameterValidator, propertyValidator, updateAdvert);
 router.patch('/:propertyId/sold', checkToken, parameterValidator, markSold);
 router.delete('/:propertyId', checkToken, parameterValidator, deleteAdvert);
+router.get('/', checkToken, getAllAdverts);
 
 
 export default router;

--- a/Server/controllers/property.controller.js
+++ b/Server/controllers/property.controller.js
@@ -79,4 +79,18 @@ export default class Property {
       return serverError(res);
     }
   }
+
+  static async getAllAdverts(req, res) {
+    try {
+      const columns = `p.id, p.status, p.type, p.state, p.city, p.address, p.price, p.created_on, p.image_url, u.email AS ownerEmail, u.phonenumber AS ownerPhoneNumber`;
+      const otherTables = `users`;
+      const alias1 = `p`; const alias2 = `u`;
+      const condition = `ON u.id=p.owner`;
+      const result = await propModel.selectAndJoin(columns, alias1, otherTables, alias2, condition);
+      if (!result.length) return serverResponse(res, 404, ...['status', 'error', 'error', `Not Advert found`]);
+      return serverResponse(res, 200, ...['status', 'success', 'data', result]);
+    } catch (err) {
+      return serverError(res);
+    }
+  }
 }

--- a/Server/test/app.test.js
+++ b/Server/test/app.test.js
@@ -159,6 +159,30 @@ describe('TESTING PROPERTY ENDPOINTS', () => {
         done();
       });
   });
+  it('should get all properties posted on the app', (done) => {
+    chai.request(server)
+      .get('/api/v1/property')
+      .set('Authorization', `Bearer ${testToken}`)
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res.body).to.have.keys('status', 'data');
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.ownProperty('status').that.equals('success');
+        expect(res.body).to.have.ownProperty('data').to.be.an('array');
+        expect(res.body.data[0].id).to.be.a('number');
+        expect(res.body.data[0].status).to.be.a('string');
+        expect(res.body.data[0].state).to.be.a('string');
+        expect(res.body.data[0].type).to.be.a('string');
+        expect(res.body.data[0].city).to.be.a('string');
+        expect(res.body.data[0].address).to.be.a('string');
+        expect(res.body.data[0].image_url).to.be.a('string');
+        expect(res.body.data[0].price).to.be.a('number');
+        expect(res.body.data[0].owneremail).to.be.a('string');
+        expect(res.body.data[0].ownerphonenumber).to.be.a('string');
+        done();
+      });
+  });
   it('should delete a property advert', (done) => {
     chai.request(server)
       .delete('/api/v1/property/1')


### PR DESCRIPTION
#### What does this PR do?
Implements the get-all-properties-advert endpoint for the Property Pro Lite
#### Description of Task to be completed?
- write tests for the get-all-properties-advert endpoint
- write the get-all-properties-advert endpoint.
- run tests on endpoint and ensure it passes.

#### How should this be manually tested?
 - clone repository
- startup terminal
- cd into the cloned repository
- start server by typing ```npm start``` into the terminal
- Enter requested values into postman and see result.

#### Any background context you want to provide?
This is the re-implementation of challenge-2 get-all-properties-advert endpoint built using only data structures.
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/167220446
#### Screenshots (if appropriate)
None
#### Questions:
None