### PR TITLE
#167223404 implement endpoint to retrieve a specific property advert

### DIFF
--- a/Server/Routes/property.routes.js
+++ b/Server/Routes/property.routes.js
@@ -8,7 +8,7 @@ import { propertyValidator, parameterValidator } from '../middleware/validator';
 const router = Router();
 
 const {
-  postAdvert, updateAdvert, markSold, getAllAdverts, deleteAdvert
+  postAdvert, updateAdvert, markSold, getOneAdvert, getAllAdverts, deleteAdvert
 } = propController;
 
 router.post('/', checkToken, cloudinaryConfig, multerUploads, propertyValidator, postAdvert);
@@ -16,6 +16,7 @@ router.patch('/:propertyId', checkToken, cloudinaryConfig, multerUploads, parame
 router.patch('/:propertyId/sold', checkToken, parameterValidator, markSold);
 router.delete('/:propertyId', checkToken, parameterValidator, deleteAdvert);
 router.get('/', checkToken, getAllAdverts);
+router.get('/:propertyId', checkToken, parameterValidator, getOneAdvert);
 
 
 export default router;

--- a/Server/controllers/property.controller.js
+++ b/Server/controllers/property.controller.js
@@ -98,4 +98,18 @@ export default class Property {
       return serverResponse(res, 500, ...['status', 'error', 'error', `Something went wrong. Try again later`]);
     }
   }
+
+  static async getOneAdvert(req, res) {
+    try {
+      const id = Number(req.params.propertyId);
+      const columns = `p.id, p.status, p.type, p.state, p.city, p.address, p.price, p.created_on, p.image_url, u.email AS owner_email, u.phonenumber AS owner_phone_number`;
+      const otherTables = `users`; const alias1 = `p`; const alias2 = `u`;
+      const condition = `ON u.id=p.owner WHERE p.id = ${id}`;
+      const result = await propModel.selectAndJoin(columns, alias1, otherTables, alias2, condition);
+      if (!result.length) return serverResponse(res, 404, ...['status', 'error', 'error', 'No result found. Enter a valid value and try again.']);
+      return serverResponse(res, 200, ...['status', 'success', 'data', result[0]]);
+    } catch (err) {
+      return serverResponse(res, 500, ...['status', 'error', 'error', `Something went wrong. Try again later`]);
+    }
+  }
 }

--- a/Server/test/app.test.js
+++ b/Server/test/app.test.js
@@ -164,6 +164,30 @@ describe('TESTING PROPERTY ENDPOINTS', () => {
         done();
       });
   });
+  it('should retrieve A SPECIFIC PROPERTY', (done) => {
+    chai.request(server)
+      .get('/api/v1/property/1')
+      .set('Authorization', `Bearer ${testToken}`)
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res.body).to.have.keys('status', 'data');
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.ownProperty('status').that.equals('success');
+        expect(res.body).to.have.ownProperty('data').to.be.an('object');
+        expect(res.body.data.id).to.be.a('number');
+        expect(res.body.data.status).to.be.a('string');
+        expect(res.body.data.state).to.be.a('string');
+        expect(res.body.data.type).to.be.a('string');
+        expect(res.body.data.city).to.be.a('string');
+        expect(res.body.data.address).to.be.a('string');
+        expect(res.body.data.image_url).to.be.a('string');
+        expect(res.body.data.price).to.be.a('number');
+        expect(res.body.data.owner_email).to.be.a('string');
+        expect(res.body.data.owner_phone_number).to.be.a('string');
+        done();
+      });
+  });
   it('should update property advert as Sold', (done) => {
     chai.request(server)
       .patch('/api/v1/property/1/sold')


### PR DESCRIPTION
#### What does this PR do?
Implements the get-a-specific-advert endpoint for the Property Pro Lite
#### Description of Task to be completed?
- write tests for the get-a-specific-advert endpoint
- write the get-a-specific-advert endpoint.
- run tests on endpoint and ensure it passes.

#### How should this be manually tested?
 - clone repository
- startup terminal
- cd into the cloned repository
- start server by typing ```npm start``` into the terminal
- Enter requested values into postman and see result.

#### Any background context you want to provide?
This is the re-implementation of challenge-2 get-a-specific-advert endpoint built using only data structures.
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/167223404
#### Screenshots (if appropriate)
None
#### Questions:
None